### PR TITLE
Fix for arrow rendering for errors and gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 /Cargo.lock
 /Hexagn-rust.iml
 
-/test.hxgn
+/*.hxgn
 /*.urcl

--- a/src/compiler/ast/ast.rs
+++ b/src/compiler/ast/ast.rs
@@ -4,7 +4,6 @@ use super::nodes::*;
 use crate::{
     buf_consume,
     compiler::{
-        draw_arrows,
         lexer::{Token, TokenType},
         print_error,
     },
@@ -272,7 +271,6 @@ macro_rules! buf_consume {
                 $($p)|+ => { $buf.advance(); curr },
                 _ => {
                     print_error($err, $src, curr.start, curr.end, curr.lineno);
-                    draw_arrows(curr.start, curr.end, curr.lineno);
                     exit(2)
                 }
             }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,3 @@
-use std::io::Write;
-
 pub fn get_line(src: &String, lineno: usize) -> String {
     let mut i = find_nth(src, &'\n', &(lineno - 1)) + 1;
     let mut res = String::new();
@@ -16,16 +14,16 @@ pub fn find_nth(src: &String, c: &char, nth: &usize) -> usize {
     src.match_indices(*c).nth(*nth).unwrap().0
 }
 
-pub fn draw_arrows(start: usize, end: usize, lineno: usize) {
-    let start = start + lineno.to_string().len() + 2;
-    let end = end + lineno.to_string().len() + 2;
+pub fn draw_arrows(start: usize, mut end: usize, lineno: usize) {
+    let mut msg = format!("\x1b[31m{}", " ".repeat(lineno.to_string().len()));
 
-    std::io::stderr().write_fmt(format_args!("\x1b[31m")).unwrap();
-    for _ in 0..start {
-        std::io::stderr().write_fmt(format_args!(" ")).unwrap()
+    if end == start { end += 1 }
+    for _ in 0..=start {
+        msg += " ";
     }
     for _ in start..end {
-        std::io::stderr().write_fmt(format_args!("^")).unwrap()
+        msg += "^";
     }
-    std::io::stderr().write_fmt(format_args!("\x1b[0m\n")).unwrap();
+
+    eprintln!("{}\x1b[0m", msg);
 }


### PR DESCRIPTION
Prior to the fix, arrow rendering would not **render** if the start and end were the same position. It sometimes does not align perfectly. This change *might* fix it forever, who knows. `.gitignore` has a very minor change to exclude **all** files with `.hxgn` extension.